### PR TITLE
Add input length validation for tuning and tag fields

### DIFF
--- a/lib/src/config/validation_constants.dart
+++ b/lib/src/config/validation_constants.dart
@@ -1,0 +1,5 @@
+class ValidationConstants {
+  static const int maxTuningLength = 32;
+  static const int maxTagLength = 32;
+}
+

--- a/lib/src/pages/tuning/tuning_register.dart
+++ b/lib/src/pages/tuning/tuning_register.dart
@@ -3,6 +3,8 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:drift/drift.dart' as drift;
+import 'package:flutter/services.dart';
+import 'package:tune_chord_sample/src/config/validation_constants.dart';
 import 'package:tune_chord_sample/l10n/app_localizations.dart';
 import 'package:tune_chord_sample/src/db/app_database.dart';
 import 'package:tune_chord_sample/src/pages/tuning/tuning_notifier.dart';
@@ -23,6 +25,8 @@ class TuningKeyboard extends HookWidget {
 
   void insertText(String text) {
     final currentText = controller.text;
+    if (currentText.length + text.length >
+        ValidationConstants.maxTuningLength) return;
     final newText = currentText + text;
     controller.text = newText;
     controller.selection = TextSelection.fromPosition(
@@ -144,6 +148,12 @@ class TuningRegister extends HookConsumerWidget {
               focusNode: stringsFocusNode,
               readOnly: true,
               showCursor: true,
+              inputFormatters: [
+                LengthLimitingTextInputFormatter(
+                  ValidationConstants.maxTuningLength,
+                ),
+              ],
+              maxLength: ValidationConstants.maxTuningLength,
               decoration: InputDecoration(
                 hintText: l10n.tuningExample, // 例: CGDGCD
                 filled: true,
@@ -228,13 +238,19 @@ class TuningRegister extends HookConsumerWidget {
                       builder:
                           (context) => AlertDialog(
                             title: Text(l10n.newTag), // 新規タグ
-                            content: TextField(
-                              controller: controller,
-                              autofocus: true,
-                              decoration: InputDecoration(
-                                hintText: l10n.newTag, // 新規タグ
+                          content: TextField(
+                            controller: controller,
+                            autofocus: true,
+                            inputFormatters: [
+                              LengthLimitingTextInputFormatter(
+                                ValidationConstants.maxTagLength,
                               ),
+                            ],
+                            maxLength: ValidationConstants.maxTagLength,
+                            decoration: InputDecoration(
+                              hintText: l10n.newTag, // 新規タグ
                             ),
+                          ),
                             actions: [
                               TextButton(
                                 onPressed: () => Navigator.pop(context),
@@ -242,10 +258,13 @@ class TuningRegister extends HookConsumerWidget {
                               ),
                               TextButton(
                                 onPressed: () {
-                                  if (controller.text.trim().isNotEmpty) {
+                                  final text = controller.text.trim();
+                                  if (text.isNotEmpty &&
+                                      text.length <=
+                                          ValidationConstants.maxTagLength) {
                                     Navigator.pop(
                                       context,
-                                      controller.text.trim(),
+                                      text,
                                     );
                                   }
                                 },

--- a/lib/src/pages/tuning/tuning_update_dialog.dart
+++ b/lib/src/pages/tuning/tuning_update_dialog.dart
@@ -5,6 +5,8 @@ import 'package:tune_chord_sample/l10n/app_localizations.dart';
 import 'package:tune_chord_sample/src/db/app_database.dart';
 import 'package:tune_chord_sample/src/pages/tuning/tuning_notifier.dart';
 import 'package:gap/gap.dart';
+import 'package:flutter/services.dart';
+import 'package:tune_chord_sample/src/config/validation_constants.dart';
 
 class TuningUpdateDialog extends HookConsumerWidget {
   final Tuning tuning;
@@ -71,6 +73,12 @@ class TuningUpdateDialog extends HookConsumerWidget {
             const Gap(8),
             TextField(
               controller: stringsController,
+              inputFormatters: [
+                LengthLimitingTextInputFormatter(
+                  ValidationConstants.maxTuningLength,
+                ),
+              ],
+              maxLength: ValidationConstants.maxTuningLength,
               decoration: InputDecoration(
                 hintText: l10n.tuningExample, // 例: CGDGCD
                 filled: true,


### PR DESCRIPTION
## Summary
- add validation constants
- enforce length limits for tuning text
- restrict new tag name length
- apply same limits in tuning edit dialog

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406a15f584832a8f9579bc365fbb43