### PR TITLE
fix: 検索結果タップ時のナビゲーション修正とレイアウトオーバーフロー解決

### DIFF
--- a/lib/src/pages/chordForm/chord_form_detail.dart
+++ b/lib/src/pages/chordForm/chord_form_detail.dart
@@ -51,13 +51,14 @@ class ChordFormDetail extends HookConsumerWidget {
             orElse: () => throw Exception('コードフォームが見つかりません'),
           );
 
-          return Card(
-            margin: const EdgeInsets.all(8.0),
-            child: Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
+          return SingleChildScrollView(
+            child: Card(
+              margin: const EdgeInsets.all(8.0),
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
                   Text(
                     chordForm.label ?? '',
                     style: Theme.of(context).textTheme.titleLarge,
@@ -136,6 +137,7 @@ class ChordFormDetail extends HookConsumerWidget {
                     ],
                   ),
                 ],
+                ),
               ),
             ),
           );

--- a/lib/src/pages/search/search_page.dart
+++ b/lib/src/pages/search/search_page.dart
@@ -379,7 +379,7 @@ class SearchPage extends HookConsumerWidget {
     final l10n = AppLocalizations.of(context)!;
     return InkWell(
       onTap: () {
-        context.push('/tuningList/chordFormList/${tuning.id}');
+        context.go('/tuningList/chordFormList/${tuning.id}');
       },
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -445,7 +445,7 @@ class SearchPage extends HookConsumerWidget {
     final l10n = AppLocalizations.of(context)!;
     return InkWell(
       onTap: () {
-        context.push(
+        context.go(
           '/tuningList/chordFormList/${chordForm.tuningId}/chordFormDetail',
           extra: chordForm.id,
         );


### PR DESCRIPTION
- 検索結果からcontext.pushをcontext.goに変更し、適切なタブへの遷移を実現
- ChordFormDetailページでSingleChildScrollViewを追加してオーバーフロー問題を解決
- サーチタブからチューニングタブへの自動切り替えでUXを改善

🤖 Generated with [Claude Code](https://claude.ai/code)